### PR TITLE
Pad day number with a leading zero in submit command

### DIFF
--- a/solution_runner/commands/submit_command.py
+++ b/solution_runner/commands/submit_command.py
@@ -51,7 +51,7 @@ def _parse_result(result: str) -> tuple[str, bool]:
 def command(year: int, day: int, part: int):
     """Submit solution."""
     year = str(year)
-    day = str(day)
+    day = str(day).zfill(2)
 
     root_directory = get_setting(consts.ROOT_DIRECTORY)
     solutions_directory = root_directory / Directories.SOLUTIONS / year / f"d{day}"


### PR DESCRIPTION
Previously, it was done in the setup command only, which meant the submit command was looking for the wrong path (without the preceding zero).
