### PR TITLE
Add `tzdata` dependency to packages requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ click
 pyyaml
 beautifulsoup4
 black
+tzdata


### PR DESCRIPTION
From the [Python documentation](https://docs.python.org/3/library/zoneinfo.html#data-sources):
> The `zoneinfo` module does not directly provide time zone data, and instead pulls time zone information from the system time zone database or the first-party PyPI package [tzdata](https://pypi.org/project/tzdata/), if available. Some systems, including notably Windows systems, do not have an IANA database available, and so for projects targeting cross-platform compatibility that require time zone data, it is recommended to declare a dependency on tzdata.