### PR TITLE
Solve 2025 day 3

### DIFF
--- a/puzzles/solutions/2025/d03/p1.py
+++ b/puzzles/solutions/2025/d03/p1.py
@@ -1,0 +1,14 @@
+import sys
+
+
+def get_answer(input_text: str):
+    raise NotImplementedError
+
+
+if __name__ == "__main__":
+    try:
+        print(get_answer(sys.argv[1]))
+    except IndexError:
+        print(
+            "Warning: No input provided", file=sys.stderr
+        )  # Don't crash if no input was passed through command line arguments.

--- a/puzzles/solutions/2025/d03/p1.py
+++ b/puzzles/solutions/2025/d03/p1.py
@@ -1,6 +1,10 @@
 import sys
 
 
+def get_banks(input_text: str) -> list[list[int]]:
+    return [list(map(int, line)) for line in input_text.splitlines()]
+
+
 def get_answer(input_text: str):
     raise NotImplementedError
 

--- a/puzzles/solutions/2025/d03/p1.py
+++ b/puzzles/solutions/2025/d03/p1.py
@@ -1,4 +1,3 @@
-import itertools
 import sys
 
 
@@ -10,9 +9,10 @@ def get_answer(input_text: str):
     banks = get_banks(input_text)
     max_joltages = 0
     for bank in banks:
-        bank_joltages = itertools.combinations(bank, 2)
-        max_joltage = max(bank_joltages)
-        max_joltages += max_joltage[0] * 10 + max_joltage[1]
+        tens_digit = max(bank[:-1])
+        tens_digit_first_index = bank.index(tens_digit)
+        ones_digit = max(bank[tens_digit_first_index + 1 :])
+        max_joltages += tens_digit * 10 + ones_digit
     return max_joltages
 
 

--- a/puzzles/solutions/2025/d03/p1.py
+++ b/puzzles/solutions/2025/d03/p1.py
@@ -6,7 +6,16 @@ def get_banks(input_text: str) -> list[list[int]]:
 
 
 def get_answer(input_text: str):
-    raise NotImplementedError
+    banks = get_banks(input_text)
+    max_joltages = 0
+    for bank in banks:
+        max_joltage = 0
+        for first_index, first_joltage in enumerate(bank):
+            for _, second_joltage in enumerate(bank[first_index + 1 :]):
+                if (joltage := first_joltage * 10 + second_joltage) > max_joltage:
+                    max_joltage = joltage
+        max_joltages += max_joltage
+    return max_joltages
 
 
 if __name__ == "__main__":

--- a/puzzles/solutions/2025/d03/p1.py
+++ b/puzzles/solutions/2025/d03/p1.py
@@ -1,3 +1,4 @@
+import itertools
 import sys
 
 
@@ -9,12 +10,9 @@ def get_answer(input_text: str):
     banks = get_banks(input_text)
     max_joltages = 0
     for bank in banks:
-        max_joltage = 0
-        for first_index, first_joltage in enumerate(bank):
-            for _, second_joltage in enumerate(bank[first_index + 1 :]):
-                if (joltage := first_joltage * 10 + second_joltage) > max_joltage:
-                    max_joltage = joltage
-        max_joltages += max_joltage
+        bank_joltages = itertools.combinations(bank, 2)
+        max_joltage = max(bank_joltages)
+        max_joltages += max_joltage[0] * 10 + max_joltage[1]
     return max_joltages
 
 

--- a/puzzles/solutions/2025/d03/p1.py
+++ b/puzzles/solutions/2025/d03/p1.py
@@ -7,13 +7,13 @@ def get_banks(input_text: str) -> list[list[int]]:
 
 def get_answer(input_text: str):
     banks = get_banks(input_text)
-    max_joltages = 0
+    total_max_joltages = 0
     for bank in banks:
         tens_digit = max(bank[:-1])
         tens_digit_first_index = bank.index(tens_digit)
         ones_digit = max(bank[tens_digit_first_index + 1 :])
-        max_joltages += tens_digit * 10 + ones_digit
-    return max_joltages
+        total_max_joltages += tens_digit * 10 + ones_digit
+    return total_max_joltages
 
 
 if __name__ == "__main__":

--- a/puzzles/solutions/2025/d03/p2.py
+++ b/puzzles/solutions/2025/d03/p2.py
@@ -1,0 +1,14 @@
+import sys
+
+
+def get_answer(input_text: str):
+    raise NotImplementedError
+
+
+if __name__ == "__main__":
+    try:
+        print(get_answer(sys.argv[1]))
+    except IndexError:
+        print(
+            "Warning: No input provided", file=sys.stderr
+        )  # Don't crash if no input was passed through command line arguments.

--- a/puzzles/solutions/2025/d03/p2.py
+++ b/puzzles/solutions/2025/d03/p2.py
@@ -1,8 +1,25 @@
 import sys
 
+from p1 import get_banks
+
+BATTERIES_AMOUNT = 12
+
 
 def get_answer(input_text: str):
-    raise NotImplementedError
+    banks = get_banks(input_text)
+    max_joltages = 0
+    for bank in banks:
+        max_joltage = 0
+        current_index = 0
+        for digit_number in range(BATTERIES_AMOUNT):
+            last_possible_index = 1 + digit_number - BATTERIES_AMOUNT
+            if last_possible_index == 0:
+                last_possible_index = len(bank)
+            max_digit = max(bank[current_index:last_possible_index])
+            current_index = bank.index(max_digit, current_index) + 1
+            max_joltage += max_digit * 10 ** (BATTERIES_AMOUNT - digit_number - 1)
+        max_joltages += max_joltage
+    return max_joltages
 
 
 if __name__ == "__main__":

--- a/puzzles/solutions/2025/d03/p2.py
+++ b/puzzles/solutions/2025/d03/p2.py
@@ -13,7 +13,9 @@ def get_answer(input_text: str):
         max_joltage = 0
         current_index = 0
         for digit_number in range(BATTERIES_AMOUNT):
-            last_possible_index = bank_size + 1 + digit_number - BATTERIES_AMOUNT
+            remaining_digits_needed_after_this = BATTERIES_AMOUNT - digit_number - 1
+            # Slicing is exclusive, so we don't need to subtract another 1.
+            last_possible_index = bank_size - remaining_digits_needed_after_this
             max_digit = max(bank[current_index:last_possible_index])
             current_index = bank.index(max_digit, current_index) + 1
             max_joltage = (max_joltage * 10) + max_digit

--- a/puzzles/solutions/2025/d03/p2.py
+++ b/puzzles/solutions/2025/d03/p2.py
@@ -7,7 +7,7 @@ BATTERIES_AMOUNT = 12
 
 def get_answer(input_text: str):
     banks = get_banks(input_text)
-    max_joltages = 0
+    total_max_joltages = 0
     for bank in banks:
         bank_size = len(bank)
         max_joltage = 0
@@ -19,8 +19,8 @@ def get_answer(input_text: str):
             max_digit = max(bank[current_index:last_possible_index])
             current_index = bank.index(max_digit, current_index) + 1
             max_joltage = (max_joltage * 10) + max_digit
-        max_joltages += max_joltage
-    return max_joltages
+        total_max_joltages += max_joltage
+    return total_max_joltages
 
 
 if __name__ == "__main__":

--- a/puzzles/solutions/2025/d03/p2.py
+++ b/puzzles/solutions/2025/d03/p2.py
@@ -16,7 +16,7 @@ def get_answer(input_text: str):
             last_possible_index = bank_size + 1 + digit_number - BATTERIES_AMOUNT
             max_digit = max(bank[current_index:last_possible_index])
             current_index = bank.index(max_digit, current_index) + 1
-            max_joltage += max_digit * 10 ** (BATTERIES_AMOUNT - digit_number - 1)
+            max_joltage = (max_joltage * 10) + max_digit
         max_joltages += max_joltage
     return max_joltages
 

--- a/puzzles/solutions/2025/d03/p2.py
+++ b/puzzles/solutions/2025/d03/p2.py
@@ -9,12 +9,11 @@ def get_answer(input_text: str):
     banks = get_banks(input_text)
     max_joltages = 0
     for bank in banks:
+        bank_size = len(bank)
         max_joltage = 0
         current_index = 0
         for digit_number in range(BATTERIES_AMOUNT):
-            last_possible_index = 1 + digit_number - BATTERIES_AMOUNT
-            if last_possible_index == 0:
-                last_possible_index = len(bank)
+            last_possible_index = bank_size + 1 + digit_number - BATTERIES_AMOUNT
             max_digit = max(bank[current_index:last_possible_index])
             current_index = bank.index(max_digit, current_index) + 1
             max_joltage += max_digit * 10 ** (BATTERIES_AMOUNT - digit_number - 1)


### PR DESCRIPTION
There are batteries nearby that can supply emergency power to the escalator for just such an occasion. The batteries are each labeled with their [joltage](https://adventofcode.com/2020/day/10) rating, a value from 1 to 9. You make a note of their joltage ratings (your puzzle input). For example:

987654321111111
811111111111119
234234234234278
818181911112111
The batteries are arranged into banks; each line of digits in your input corresponds to a single bank of batteries. Within each bank, you need to turn on exactly two batteries; the joltage that the bank produces is equal to the number formed by the digits on the batteries you've turned on. For example, if you have a bank like 12345 and you turn on batteries 2 and 4, the bank would produce 24 jolts. (You cannot rearrange batteries.)

You'll need to find the largest possible joltage each bank can produce. In the above example:

In 987654321111111, you can make the largest joltage possible, 98, by turning on the first two batteries.
In 811111111111119, you can make the largest joltage possible by turning on the batteries labeled 8 and 9, producing 89 jolts.
In 234234234234278, you can make 78 by turning on the last two batteries (marked 7 and 8).
In 818181911112111, the largest joltage you can produce is 92.
The total output joltage is the sum of the maximum joltage from each bank, so in this example, the total output joltage is 98 + 89 + 78 + 92 = 357.

There are many batteries in front of you. Find the maximum joltage possible from each bank; what is the total output joltage?

Your puzzle answer was 16887.

--- Part Two ---
The escalator doesn't move. The Elf explains that it probably needs more joltage to overcome the [static friction](https://en.wikipedia.org/wiki/Static_friction) of the system and hits the big red "joltage limit safety override" button. You lose count of the number of times she needs to confirm "yes, I'm sure" and decorate the lobby a bit while you wait.

Now, you need to make the largest joltage by turning on exactly twelve batteries within each bank.

The joltage output for the bank is still the number formed by the digits of the batteries you've turned on; the only difference is that now there will be 12 digits in each bank's joltage output instead of two.

Consider again the example from before:

987654321111111
811111111111119
234234234234278
818181911112111
Now, the joltages are much larger:

In 987654321111111, the largest joltage can be found by turning on everything except some 1s at the end to produce 987654321111.
In the digit sequence 811111111111119, the largest joltage can be found by turning on everything except some 1s, producing 811111111119.
In 234234234234278, the largest joltage can be found by turning on everything except a 2 battery, a 3 battery, and another 2 battery near the start to produce 434234234278.
In 818181911112111, the joltage 888911112111 is produced by turning on everything except some 1s near the front.
The total output joltage is now much larger: 987654321111 + 811111111119 + 434234234278 + 888911112111 = 3121910778619.

What is the new total output joltage?

Your puzzle answer was 167302518850275.